### PR TITLE
Use text selection when sharing emails

### DIFF
--- a/src/selection-sharer.js
+++ b/src/selection-sharer.js
@@ -246,7 +246,7 @@
     };
 
     this.shareEmail = function(e) {
-      var text = self.htmlSelection.replace(/<p[^>]*>/ig,'\n').replace(/<\/p>|  /ig,'').trim();
+      var text = self.textSelection.replace(/<p[^>]*>/ig,'\n').replace(/<\/p>|  /ig,'').trim();
       var email = {};
       email.subject = encodeURIComponent("Quote from "+document.title);
       email.body = encodeURIComponent("“"+text+"”")+"%0D%0A%0D%0AFrom: "+document.title+"%0D%0A"+window.location.href;


### PR DESCRIPTION
When a email is shared using this option the tags aren't cleaned. So using text selection i don't have this problem.

I had this problem using kmail from kubuntu, i'm not sure if this happens with other mail clients.