### PR TITLE
Adding Epic Sharer plugin for WordPress

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ This is still early days so there is still a lot to do and I welcome contributio
 TODO:
 
 - Make a browser extension
-- Make a Wordpress plugin - done by @jcvangent http://wordpress.org/plugins/selection-sharer/ 
+- Make a Wordpress plugin - done by @jcvangent http://wordpress.org/plugins/selection-sharer/ ,@ishansharma https://wordpress.org/plugins/epic-selection-sharer/
 - Add support for different themes
 - Add tests
 - Tests across multiple browsers (currently only tested on Chrome, Safari, Firefox on a Mac)


### PR DESCRIPTION
Added my username and link to WP plugin. https://wordpress.org/plugins/epic-selection-sharer/

I have made this plugin with customisability in mind. V1 has options for hiding and showing on post types and specifying twitter handle of author. 